### PR TITLE
HTML Data Source Plugin

### DIFF
--- a/.idea/Graph-Visualizer.iml
+++ b/.idea/Graph-Visualizer.iml
@@ -17,9 +17,10 @@
       <sourceFolder url="file://$MODULE_DIR$/graph_visualizer_api/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/graph_visualizer_core/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/graph_visualizer_platform/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/html_data_source_plugin/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="Python 3.10 (Graph-Visualizer)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="TemplatesService">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.12 (Graph-Visualizer)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.9" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (Graph-Visualizer)" project-jdk-type="Python SDK" />
   <component name="PythonCompatibilityInspectionAdvertiser">
     <option name="version" value="3" />
   </component>

--- a/graph_visualizer_api/src/graph_visualizer_api/model/edge.py
+++ b/graph_visualizer_api/src/graph_visualizer_api/model/edge.py
@@ -34,3 +34,6 @@ class Edge:
 
     def __eq__(self, other: Edge) -> bool:
         return self._source == other._source and self._target == other._target
+
+    def __str__(self) -> str:
+        return f'Edge[{self._source.node_id}, {self._target.node_id}]'

--- a/graph_visualizer_api/src/graph_visualizer_api/model/graph.py
+++ b/graph_visualizer_api/src/graph_visualizer_api/model/graph.py
@@ -1,7 +1,7 @@
 from .node import Node
 from .edge import Edge
 from .exceptions import GraphError
-from typing import Optional
+from typing import Optional, Any
 
 
 class Graph:
@@ -102,3 +102,18 @@ class Graph:
             raise GraphError("target node does not exist")
 
         return next((edge for edge in self._edges if source == edge.source and target == edge.target), None)
+
+    def get_node_by_attribute(self, attribute: str, value: Any) -> Optional[Node]:
+        """Returns a node by its attribute.
+
+        :param attribute: Attribute of the node.
+        :param value: Value for the given attribute.
+        :returns: Node if found or None.
+        """
+
+        return next((node for node in self._nodes if value == node.data.get(attribute)), None)
+
+    def __str__(self) -> str:
+        nodes = ''.join([f'{node}\n' for node in self._nodes])
+        edges = ''.join([f'{edge}\n' for edge in self._edges])
+        return nodes + edges

--- a/graph_visualizer_api/src/graph_visualizer_api/model/graph.py
+++ b/graph_visualizer_api/src/graph_visualizer_api/model/graph.py
@@ -103,15 +103,15 @@ class Graph:
 
         return next((edge for edge in self._edges if source == edge.source and target == edge.target), None)
 
-    def get_node_by_attribute(self, attribute: str, value: Any) -> Optional[Node]:
-        """Returns a node by its attribute.
+    def get_nodes_by_attributes(self, **kwargs) -> list[Node]:
+        """Returns a list of nodes by their attributes.
+        Checks if the given argument dictionary is a subset of the node data.
 
-        :param attribute: Attribute of the node.
-        :param value: Value for the given attribute.
+        :param kwargs: Dictionary of key/values that are used to filter nodes.
         :returns: Node if found or None.
         """
 
-        return next((node for node in self._nodes if value == node.data.get(attribute)), None)
+        return [node for node in self._nodes if kwargs.items() <= node.data.items()]
 
     def __str__(self) -> str:
         nodes = ''.join([f'{node}\n' for node in self._nodes])

--- a/graph_visualizer_api/src/graph_visualizer_api/model/node.py
+++ b/graph_visualizer_api/src/graph_visualizer_api/model/node.py
@@ -27,3 +27,6 @@ class Node:
 
     def __hash__(self) -> int:
         return hash(self._node_id)
+
+    def __str__(self) -> str:
+        return f'Node[{self._node_id}]'

--- a/graph_visualizer_api/tests/test_graph.py
+++ b/graph_visualizer_api/tests/test_graph.py
@@ -119,3 +119,15 @@ class TestGraph(unittest.TestCase):
 
         self.assertEqual(0, len(graph.edges))
         self.assertIsNone(graph.get_edge(node1, node2))
+
+    def test_find_by_attribute(self):
+        node1 = Node(1, {'name': 'Pera'})
+        node2 = Node(2, {'name': 'Djura', 'age': 25})
+        node3 = Node(3, {})
+        node4 = Node(4, {'age': 25})
+        graph = Graph([node1, node2, node3, node4], [])
+
+        self.assertEqual(0, len(graph.get_nodes_by_attributes(job='baker')))
+        self.assertEqual(2, len(graph.get_nodes_by_attributes(age=25)))
+        self.assertEqual(node1, graph.get_nodes_by_attributes(name='Pera')[0])
+        self.assertEqual(0, len(graph.get_nodes_by_attributes(name='Mika')))

--- a/html_data_source_plugin/pyproject.toml
+++ b/html_data_source_plugin/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "html_data_source_plugin"
+authors = [
+    { name = "Vladislav Radović", email = "radovic.sv27.2021@uns.ac.rs" },
+]
+description = "HTML Data Source Plugin for Graph Visualizer"
+requires-python = ">=3.9"
+classifiers = [
+    "Programming Language :: Python :: 3",
+]
+dependencies = [
+    "beautifulsoup4",
+    "graph_visualizer_api",
+    "requests",
+    "urllib3",
+]
+dynamic = ["version"]

--- a/html_data_source_plugin/src/html_data_source_plugin/datasource.py
+++ b/html_data_source_plugin/src/html_data_source_plugin/datasource.py
@@ -59,7 +59,8 @@ class HtmlDataSource(DataSource):
             return
 
         # Handle existing node
-        node = self._graph.get_node_by_attribute('url', node_url)
+        nodes = self._graph.get_nodes_by_attributes(url=node_url)
+        node = nodes[0] if len(nodes) > 0 else None
         if node is not None and previous_node is not None:
             edge = self._graph.get_edge(previous_node, node)
             if edge is None:

--- a/html_data_source_plugin/src/html_data_source_plugin/datasource.py
+++ b/html_data_source_plugin/src/html_data_source_plugin/datasource.py
@@ -1,0 +1,96 @@
+from bs4 import BeautifulSoup
+from graph_visualizer_api.datasource import DataSource
+from graph_visualizer_api.model.graph import Graph
+from graph_visualizer_api.model.node import Node
+from graph_visualizer_api.model.edge import Edge
+from html_data_source_plugin.provider import get_links, provide_for_url, get_metadata
+from typing import Optional
+from urllib.parse import urljoin
+
+
+class HtmlDataSource(DataSource):
+    """Scrapes and parses HTML to Graph.
+
+    This is a plugin that implements the data source for the Graph Visualizer. It scrapes html pages and parses them
+    to nodes. Each link to a node is parsed to an edge.
+
+    Attributes:
+        _base_url: Starting point for the scraper.
+        _node_cap: Maximum number of nodes to be built.
+        _next_node_id: Assigned to the next page.
+        _graph: Parsed graph.
+    """
+
+    def __init__(self, base_url: str = 'http://www.scrapethissite.com', node_cap: int = 200):
+        self._base_url = base_url
+        self._node_cap = node_cap
+        self._next_node_id = 1
+        self._graph = Graph([], [])
+
+    def _build_node(self, soup: BeautifulSoup, url: str) -> Node:
+        """Builds the node from the soup object.
+
+        :param soup: BeautifulSoup object.
+        :param url: URL from which the soup object was created.
+        :returns: Node object.
+        """
+
+        node_id = self._next_node_id
+        self._next_node_id += 1
+
+        node_data = {
+            'url': url,
+        }
+        node_data.update(get_metadata(soup))
+
+        print(f'Building node {node_id}...')
+        return Node(node_id, node_data)
+
+    def _process_node(self, node_url: str, previous_node: Optional[Node]) -> None:
+        """Parses the page from the url.
+
+        This is a recursive method and will be applied for each child of the current node i.e. the hyperlinks.
+
+        :param node_url: The node URL.
+        :param previous_node: Previous node.
+        """
+
+        if self._next_node_id > self._node_cap:
+            return
+
+        # Handle existing node
+        node = self._graph.get_node_by_attribute('url', node_url)
+        if node is not None and previous_node is not None:
+            edge = self._graph.get_edge(previous_node, node)
+            if edge is None:
+                self._graph.add_edge(Edge(previous_node, node, {}))
+            return
+
+        soup = provide_for_url(node_url)
+
+        new_node = self._build_node(soup, node_url)
+        self._graph.add_node(new_node)
+
+        if previous_node is not None:
+            self._graph.add_edge(Edge(previous_node, new_node, {}))  # TODO: add edge data
+
+        links = get_links(soup)
+        for link in links:
+            path = ''
+            if link and link.startswith('/'):
+                path = urljoin(self._base_url, link)
+            elif link and link.startswith('http'):
+                path = link
+            else:  # If no format is satisfied
+                return
+
+            self._process_node(path, new_node)
+
+    def generate_graph(self) -> Graph:
+        """Creates the graph.
+
+        :return: Graph object.
+        """
+        self._process_node(self._base_url, None)
+
+        return self._graph

--- a/html_data_source_plugin/src/html_data_source_plugin/main.py
+++ b/html_data_source_plugin/src/html_data_source_plugin/main.py
@@ -1,0 +1,14 @@
+from html_data_source_plugin.datasource import HtmlDataSource
+import time
+
+if __name__ == '__main__':
+    html_data_source = HtmlDataSource()
+
+    start = time.time()
+    graph = html_data_source.generate_graph()
+    end = time.time()
+
+    print(graph)
+    print(f'Number of nodes: {len(graph.nodes)}')
+    print(f'Number of edges: {len(graph.edges)}')
+    print(f'Time elapsed: {end - start}')

--- a/html_data_source_plugin/src/html_data_source_plugin/provider.py
+++ b/html_data_source_plugin/src/html_data_source_plugin/provider.py
@@ -1,0 +1,41 @@
+from bs4 import BeautifulSoup
+import requests
+
+
+def provide_for_url(url: str) -> BeautifulSoup:
+    """Returns soup object for given url.
+
+    :param url: URL of the html document.
+    :return: BeautifulSoup object.
+    """
+    response = requests.get(url)
+    return BeautifulSoup(response.text, 'html.parser')
+
+
+def get_links(soup: BeautifulSoup) -> list[str]:
+    """Returns all hyperlink references.
+
+    :param soup: BeautifulSoup object
+    :returns: List of hyperlink references.
+    """
+
+    links = soup.find_all('a')
+
+    return [link.get('href') for link in links]
+
+
+def get_metadata(soup: BeautifulSoup) -> dict[str, str]:
+    """Extracts metadata from soup object.
+
+    :param soup: BeautifulSoup object.
+    :return: Dictionary containing the metadata.
+    """
+
+    description = soup.find('meta', {'name': 'description'})
+    charset = soup.find('meta[charset]')
+
+    return {
+        'title': soup.title if soup.title else 'No title',
+        'description': description['content'] if description else 'No description',
+        'charset': charset['charset'] if charset else 'No charset',
+    }


### PR DESCRIPTION
Adds the data source plugin for parsing html pages to graphs.
Closes #21 

## How it works
The plugin consists of two modules: `provider.py` and `datasource.py`.

The provider module consists of utility functions for sending requests for html pages, scraping the page for links, etc.

The datasource module consists of the implementation of the abstract DataSource class and exposes the main method for generating the graph. Internally, it relies on the provider module and crawls web pages and builds a node for each document. Metadata is being saved for each page in the node data.The constructor for the DataSource class accepts the `node_cap` (maximum number of nodes to build) and `base_url` (starting point for crawling).

### Configurability
Right now, the plugin is set to use default values for the base url and node cap. In the future, we should look into how we can expose the configuration in the platform, so the user can configure these parameters.

## Changes in API
There is only one method added to the graph API: `get_nodes_by_attributes`. The argument is provided as kwargs. Kwargs are a dictionary, so every node that satisfies the condition *kwargs are a subset of node data* is returned to the resulting list of nodes.

This addition does not interfere with the rest of the API. The test is provided for this method in the `test_graph` module.

Also, the \_\_str__ methods have been added for the node, edge and graph so they can be printed to the console.